### PR TITLE
fix an issue with downloading some artifacts

### DIFF
--- a/script/dependency-monkey.sh
+++ b/script/dependency-monkey.sh
@@ -163,7 +163,7 @@ echo "- configuring docker network"
 docker network create dependency-monkey
 
 echo "- starting up an HTTP proxy"
-docker run --network dependency-monkey --name=dependency-monkey-proxy -d -p 3128:3128 datadog/squid
+docker run --network dependency-monkey --name=dependency-monkey-proxy -d -p 3128:3128 ubuntu/squid:5.2-22.04_beta
 
 # echo "- priming m2 cache with top-level plugin dependencies"
 "${DOCKER_CMD[@]}" ./compile.pl "${BUILD_ARGS[@]}" -Dsilent=true -N dependency:resolve dependency:resolve-plugins

--- a/script/download-artifacts.pl
+++ b/script/download-artifacts.pl
@@ -18,6 +18,7 @@ use URI::Escape;
 
 use vars qw(
   $API_TOKEN
+  $HELP
   $INCLUDE_FAILED
   $MATCH
   $PRIME
@@ -28,6 +29,7 @@ use vars qw(
   $PROJECT_ROOT
 );
 
+$HELP = 0;
 $INCLUDE_FAILED = 0;
 $PRIME = 0;
 $VAULT = 0;
@@ -47,7 +49,13 @@ our $VAULT_MAPPING = [
 $CIRCLECI_API_ROOT = 'https://circleci.com/api/v1.1';
 $PROJECT_ROOT = $CIRCLECI_API_ROOT . '/project/gh/OpenNMS/opennms';
 
+sub usage() {
+  print "usage: $0 [--vault-layout] [--prime] [--include-failed] [--token=circle-api-token] [--workflow=hash] [--match=match] <all|deb|rpm|oci|json|tgz|tar.gz|xml|yml> <branch> [download-directory]\n\n";
+  exit(1);
+}
+
 GetOptions(
+  "help"           => \$HELP,
   "match=s"        => \$MATCH,
   "prime"          => \$PRIME,
   "token=s"        => \$API_TOKEN,
@@ -60,9 +68,8 @@ my $extension   = shift(@ARGV);
 my $branch      = shift(@ARGV);
 my $download_to = shift(@ARGV) || '.';
 
-if (not defined $branch) {
-  print "usage: $0 [--vault-layout] [--prime] [--include-failed] [--token=circle-api-token] [--workflow=hash] [--match=match] <all|deb|rpm|oci|json|tgz|tar.gz|xml|yml> <branch> [download-directory]\n\n";
-  exit(1);
+if ($HELP or not defined $branch) {
+  usage();
 }
 
 if ($PRIME) {
@@ -104,7 +111,6 @@ sub toEpoch($) {
   }
   return DateTime::Format::ISO8601->parse_datetime($datetime)->epoch();
 }
-
 
 # sort newest to oldest
 for my $entry (sort { toEpoch($b->{'start_time'}) - toEpoch($a->{'start_time'}) } @$decoded) {
@@ -156,6 +162,44 @@ for my $entry (sort { toEpoch($b->{'start_time'}) - toEpoch($a->{'start_time'}) 
   $workflow->{'builds'}->{$job_name} = $build_num;
 }
 
+sub get_filename_from_url($) {
+  my $url = shift;
+
+  my ($filename) = $url =~ /^.*\/([^\/]+)$/;
+  return $filename;
+}
+
+sub url_matches($) {
+  my $url = shift;
+  my $filename = get_filename_from_url($url);
+
+  my ($filepart, $ext);
+  for my $try (@EXTENSIONS) {
+    my $quoted = quotemeta($try);
+    if ($filename =~ qr(^(.*)\.${quoted}$)) {
+      $filepart = $1;
+      $ext = $try;
+    }
+    if (defined $filepart and defined $ext) {
+      if (grep { $_ eq $ext } @EXTENSIONS) {
+        if (defined $MATCH) {
+          my $quoted = quotemeta($MATCH);
+          if ($filepart =~ /${quoted}/i) {
+            # print "${filename} matches \"$MATCH\", extension \"${ext}\". Downloading.\n";
+            return 1;
+          }
+        } else {
+          # print "${filename} matches extension \"${ext}\". Downloading.\n";
+          return 1;
+        }
+      }
+    }
+  }
+
+  # print "${filename} does not match --match=\"${MATCH}\", extensions=\"@{EXTENSIONS}\". Skipping.\n";
+  return 0;
+}
+
 sub get_artifacts_for_workflow($) {
   my $workflow = shift;
   my $jobs = {};
@@ -175,7 +219,7 @@ sub get_artifacts_for_workflow($) {
   return $jobs;
 }
 
-sub get_artifacts_for_workspace_id($) {
+sub get_matching_artifacts_for_workspace_id($) {
   my $workspace_id = shift;
   my $workspace = $workspaces->{$workspace_id};
   if (not defined $workspace) {
@@ -183,22 +227,34 @@ sub get_artifacts_for_workspace_id($) {
     exit(1);
   }
 
-  my $jobs = {};
+  my $artifacts = {};
 
   for my $workflow (@{$workspace->{'workflows'}}) {
-    #print "workflow:", Dumper($workflow), "\n";
+    # print "workflow:", Dumper($workflow), "\n";
     my $ret = get_artifacts_for_workflow($workflow);
-    #print "artifacts:", Dumper($ret), "\n";
+    # print "artifacts:", Dumper($ret), "\n";
     for my $key (keys %{$ret}) {
-      $jobs->{$key} = $ret->{$key};
+      for my $url (@{$ret->{$key}}) {
+        my $filename = get_filename_from_url($url);
+        if ($artifacts->{$filename}) {
+          # print "already matched from a previous workflow: ", $filename, "\n";
+          next;
+        }
+        if (url_matches($url)) {
+          $artifacts->{$filename} = $url;
+        }
+      }
     }
   }
 
-  return $jobs;
+  # print "matched artifacts: ", Dumper($artifacts), "\n";
+
+  return $artifacts;
 }
 
-sub download_artifact($$) {
-  my ($url, $filename) = @_;
+sub download_artifact($) {
+  my $url = shift;
+  my $filename = get_filename_from_url($url);
 
   my $output_dir = $download_to;
   if ($VAULT) {
@@ -260,45 +316,16 @@ for my $workflow (@$workflows) {
     next;
   }
 
-  my $artifacts = get_artifacts_for_workspace_id($workspace->{'id'});
-  my @jobs = keys %$artifacts;
-  if (@jobs < 1) {
+  my $artifacts = get_matching_artifacts_for_workspace_id($workspace->{'id'});
+  if ((keys %$artifacts) < 1) {
     print "WARNING: workspace for workflow ", $id, " passed, but does not contain any artifacts. Skipping.\n";
     next;
   }
 
-  for my $job (@jobs) {
-    for my $artifact (@{$artifacts->{$job}}) {
-      my ($filename) = $artifact =~ /^.*\/([^\/]+)$/;
-      my ($filepart, $ext);
-      for my $try (@EXTENSIONS) {
-        my $quoted = quotemeta($try);
-        if ($filename =~ qr(^(.*)\.${quoted}$)) {
-          $filepart = $1;
-          $ext = $try;
-        # } else {
-        #   print "no match: $filename / $quoted\n";
-        }
-      }
-      if (defined $filepart and defined $ext) {
-        if (grep { $_ eq $ext } @EXTENSIONS) {
-          # print "extension matched: $filepart / $ext\n";
-          if (defined $MATCH) {
-            my $quoted = quotemeta($MATCH);
-            if ($filepart =~ /${quoted}/i) {
-              print "$filepart matches \"$MATCH\". Downloading.\n";
-              download_artifact($artifact, $filename);
-            # } else {
-            #   print "$filepart does not match $MATCH. Skipping.\n";
-            }
-          } else {
-            download_artifact($artifact, $filename);
-          }
-        # } else {
-        #   print "$filename DOES NOT match: @EXTENSIONS / $filepart / $ext\n";
-        }
-      }
-    }
+  # print "Downloading all matching artifacts: ", Dumper($artifacts), "\n";
+  for my $filename (keys %$artifacts) {
+    my $url = $artifacts->{$filename};
+    download_artifact($url);
   }
 
   exit(0);


### PR DESCRIPTION
While attempting to debug https://app.circleci.com/pipelines/github/OpenNMS/opennms/25879/workflows/73f4d3f9-21ea-4d21-803c-8563cd3d82fd/jobs/204116 I found that the oci artifacts were not downloading.

I ended up simplifying the algorithm quite a bit, having the walking of the workspace just get matching URLs directly and only return URLs that should be grabbed.

I've tested it with a number of our usual ways of calling it, but I figured I would get some eyeballs on it before I merge since this could affect circle.